### PR TITLE
Support Celsius

### DIFF
--- a/custom_components/envi_heater/manifest.json
+++ b/custom_components/envi_heater/manifest.json
@@ -7,5 +7,6 @@
   "dependencies": [],
   "codeowners": ["@wlatic"],
   "config_flow": true,
-  "version": "0.10.0"
+  "version": "0.10.0",
+  "platforms": ["climate"]
 }


### PR DESCRIPTION
In the Envi App I use Celsius and with the main project I always had negative C temperatures displaying. With the power of AI coding, it displays Celsuis. Also confirm Multiple Envi devices work, I have 2.